### PR TITLE
Allow for translation files and default to english

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,5 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+.DS_Store

--- a/StardewNewsFeed/EntryPoint.cs
+++ b/StardewNewsFeed/EntryPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System.Linq;
+using Netcode;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -47,7 +48,7 @@ namespace StardewNewsFeed {
         private void CheckFarmCave(object sender, DayStartedEventArgs e) {
             var farmCave = Game1.getLocationFromName(Constants.FARM_CAVE_LOCATION_NAME);
             Log($"Player Cave Choice: {Game1.player.caveChoice}");
-            if(Game1.player.caveChoice == 2) {
+            if(Game1.player.caveChoice == new NetInt(2)) {
                 CheckLocationForHarvestableObjects(farmCave);
             } else {
                 ScanLocationForFruit(farmCave);
@@ -56,7 +57,7 @@ namespace StardewNewsFeed {
         }
 
         private void CheckGreenhouse(object sender, DayStartedEventArgs e) {
-            var greenhouse = Game1.locations.SingleOrDefault(l => l.isGreenhouse);
+            var greenhouse = Game1.locations.SingleOrDefault(l => l.isGreenhouse == new NetBool(true));
             CheckLocationForHarvestableTerrain(greenhouse);
         }
 
@@ -87,24 +88,24 @@ namespace StardewNewsFeed {
         }
 
         private void CheckLocationForHarvestableObjects(GameLocation location) {
-            var itemsReadyForHarvest = location.Objects.Values.Where(o => o.readyForHarvest);
+            var numberOfItemsReadyForHarvest = location.Objects.Values.Count(o => o.readyForHarvest == new NetBool(true));
 
-            if (itemsReadyForHarvest.Any()) {
-                Game1.addHUDMessage(new HUDMessage($"There are {itemsReadyForHarvest.Count()} items ready for harvesting in the {location.getDisplayName()}", 2));
-                Log($"{itemsReadyForHarvest.Count()} items found in the {location.getDisplayName()}");
+            if (numberOfItemsReadyForHarvest > 0) {
+                Game1.addHUDMessage(new HUDMessage($"There are {numberOfItemsReadyForHarvest} items ready for harvesting in the {location.getDisplayName()}", 2));
+                Log($"{numberOfItemsReadyForHarvest} items found in the {location.getDisplayName()}");
             } else {
                 Log($"No items found in the {location.getDisplayName()}");
             }
         }
 
         private void CheckLocationForHarvestableTerrain(GameLocation location) {
-            var hoeDirtReadyForHavest = location.terrainFeatures.Pairs
+            var numberOfDirtTilesReadyForHarvest = location.terrainFeatures.Pairs
                 .Where(p => p.Value is HoeDirt)
                 .Select(p => p.Value as HoeDirt)
-                .Where(hd => hd.readyForHarvest());
+                .Count(hd => hd.readyForHarvest());
 
-            if(hoeDirtReadyForHavest.Any()) {
-                Game1.addHUDMessage(new HUDMessage($"There are {hoeDirtReadyForHavest.Count()} items ready for harvest in the {location.getDisplayName()}."));
+            if(numberOfDirtTilesReadyForHarvest > 0) {
+                Game1.addHUDMessage(new HUDMessage($"There are {numberOfDirtTilesReadyForHarvest} items ready for harvest in the {location.getDisplayName()}."));
             } else {
                 Log($"No items found in the {location.getDisplayName()}");
             }
@@ -127,7 +128,7 @@ namespace StardewNewsFeed {
                 return false;
             }
 
-            return tile.readyForHarvest;
+            return tile.readyForHarvest == new NetBool(true);
         }
         #endregion
 

--- a/StardewNewsFeed/EntryPoint.cs
+++ b/StardewNewsFeed/EntryPoint.cs
@@ -82,7 +82,8 @@ namespace StardewNewsFeed {
             foreach(var npc in e.NewLocation.getCharacters()) {
                 Log($"Checking {npc.displayName} for a birthday today");
                 if (npc.isBirthday(Game1.Date.Season, Game1.Date.DayOfMonth)) {
-                    Game1.addHUDMessage(new HUDMessage($"Today is {npc.getName()}'s birthday. Don't forget to give them a gift", 2));
+                    var message = Helper.Translation.Get("news-feed.birthday-notice", new { npcName = npc.getName() });
+                    Game1.addHUDMessage(new HUDMessage(message, 2));
                 }
             }
         }
@@ -91,10 +92,14 @@ namespace StardewNewsFeed {
             var numberOfItemsReadyForHarvest = location.Objects.Values.Count(o => o.readyForHarvest == new NetBool(true));
 
             if (numberOfItemsReadyForHarvest > 0) {
-                Game1.addHUDMessage(new HUDMessage($"There are {numberOfItemsReadyForHarvest} items ready for harvesting in the {location.getDisplayName()}", 2));
-                Log($"{numberOfItemsReadyForHarvest} items found in the {location.getDisplayName()}");
+                var message = Helper.Translation.Get("news-feed.harvest-items-found-in-location-notice", new {
+                    numberOfItems = numberOfItemsReadyForHarvest,
+                    locationName = location.getDisplayName(Helper.Translation),
+                });
+                Game1.addHUDMessage(new HUDMessage(message, 2));
+                Log($"{numberOfItemsReadyForHarvest} items found in the {location.getDisplayName(Helper.Translation)}");
             } else {
-                Log($"No items found in the {location.getDisplayName()}");
+                Log($"No items found in the {location.getDisplayName(Helper.Translation)}");
             }
         }
 
@@ -105,9 +110,13 @@ namespace StardewNewsFeed {
                 .Count(hd => hd.readyForHarvest());
 
             if(numberOfDirtTilesReadyForHarvest > 0) {
-                Game1.addHUDMessage(new HUDMessage($"There are {numberOfDirtTilesReadyForHarvest} items ready for harvest in the {location.getDisplayName()}."));
+                var message = Helper.Translation.Get("news-feed.harvest-items-found-in-location-notice", new {
+                    numberOfItems = numberOfDirtTilesReadyForHarvest,
+                    locationName = location.getDisplayName(Helper.Translation),
+                });
+                Game1.addHUDMessage(new HUDMessage(message, 2));
             } else {
-                Log($"No items found in the {location.getDisplayName()}");
+                Log($"No items found in the {location.getDisplayName(Helper.Translation)}");
             }
         }
 
@@ -115,7 +124,8 @@ namespace StardewNewsFeed {
             for (int height = 4; height < 9; height++) {
                 for (int width = 2; width < 11; width++) {
                     if (TileIsHarvestable(location, height, width)) {
-                        Game1.addHUDMessage(new HUDMessage("The bats have brought you some fruit!", 2));
+                        var message = Helper.Translation.Get("news-feed.bats-dropped-fruit-notice");
+                        Game1.addHUDMessage(new HUDMessage(message, 2));
                         return;
                     }
                 }

--- a/StardewNewsFeed/Extensions.cs
+++ b/StardewNewsFeed/Extensions.cs
@@ -1,12 +1,13 @@
-
+﻿
+using StardewModdingAPI;
 using StardewValley;
 
 namespace StardewNewsFeed {
     public static class Extensions {
 
-        public static string getDisplayName(this GameLocation @this) {
+        public static string getDisplayName(this GameLocation @this, ITranslationHelper translationHelper) {
             if(@this.Name == Constants.FARM_CAVE_LOCATION_NAME) {
-                return "Farm Cave";
+                return translationHelper.Get("news-feed.cave-display-name");
             }
             return @this.Name;
         }

--- a/StardewNewsFeed/Extensions.cs
+++ b/StardewNewsFeed/Extensions.cs
@@ -1,14 +1,14 @@
-﻿
+
 using StardewValley;
 
 namespace StardewNewsFeed {
     public static class Extensions {
 
         public static string getDisplayName(this GameLocation @this) {
-            if(@this.name == Constants.FARM_CAVE_LOCATION_NAME) {
+            if(@this.Name == Constants.FARM_CAVE_LOCATION_NAME) {
                 return "Farm Cave";
             }
-            return @this.name;
+            return @this.Name;
         }
 
     }

--- a/StardewNewsFeed/StardewNewsFeed.csproj
+++ b/StardewNewsFeed/StardewNewsFeed.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,9 +38,21 @@
     <Compile Include="Constants.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="manifest.json" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="i18n\default.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
 </Project>

--- a/StardewNewsFeed/i18n/default.json
+++ b/StardewNewsFeed/i18n/default.json
@@ -1,0 +1,6 @@
+{
+    "news-feed.birthday-notice": "Today is {{npcName}}'s birthday. Don't forget to give them a gift!",
+    "news-feed.harvest-items-found-in-location-notice": "There are {{numberOfItems}} items ready to harvest in the {{locationName}}!",
+    "news-feed.bats-dropped-fruit-notice": "The bats have brought you some fruit!",
+    "news-feed.cave-display-name": "Farm Cave"
+}


### PR DESCRIPTION
This PR addresses two issues:
1) Netcode objects were being implicitly cast to primitives during
comparison. This change updates the equality checks so that they compare
against wrapped primitives, as suggested [here](https://stardewvalleywiki.com/Modding:Migrate_to_Stardew_Valley_1.3#.E2.9A.A0_Net_fields).

2) Messages were hardcoded in english. This change adds an i18n
directory, with a default language file in english, and uses the SMAPI
translation helper to populate message content. The documentation
for internationalization can be found [here](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Translation).